### PR TITLE
with the help of a stack overflow solution (for once SO actually had …

### DIFF
--- a/src/main/java/com/codeup/runcmc/configuration/SecurityConfiguration.java
+++ b/src/main/java/com/codeup/runcmc/configuration/SecurityConfiguration.java
@@ -60,6 +60,6 @@ public class SecurityConfiguration extends WebSecurityConfigurerAdapter {
         ;
 //                This line seems to resolve the 403 error issue with making fetch requests to favorites
 //                  It may introduce unwanted vulnerabilities, however.
-        http.csrf().disable();
+//        http.csrf().disable();
     }
 }

--- a/src/main/resources/static/js/favorite.js
+++ b/src/main/resources/static/js/favorite.js
@@ -1,6 +1,9 @@
 'use strict';
 
 function favoriteClick(e){
+    //https://stackoverflow.com/a/68063240
+    let token = $("meta[name='_csrf']").attr("content");
+    let header = $("meta[name='_csrf_header']").attr("content");
     let data = e.target.dataset.topsterid;
     console.log(e.target.parentNode.nextSibling.nextSibling.outerHTML);
     let currentDisplayedNumberOfFavoritesOnTarget = parseInt((e.target.parentNode.nextSibling.nextSibling.innerText).substring(1));
@@ -8,6 +11,7 @@ function favoriteClick(e){
         method: 'POST',
         credentials: "same-origin",
         headers: {
+        [header]: token,
         'Content-Type': 'text/plain',
         'Content-Length': 0,
         'Accept': '*/*'

--- a/src/main/resources/templates/partials/partials.html
+++ b/src/main/resources/templates/partials/partials.html
@@ -1,7 +1,10 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org" xmlns:sec="http://www.w3.org/1999/xhtml" lang="en">
 <head th:fragment="head (title)">
+<!--	Lines 6 and 7 from https://stackoverflow.com/a/68063240 -->
 	<meta charset="UTF-8">
+	<meta name="_csrf" th:content="${_csrf.token}"/>
+	<meta name="_csrf_header" th:content="${_csrf.headerName}"/>
 	<title th:text="${title}"></title>
 	<!-- Font Awesome -->
 	<link href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/5.15.1/css/all.min.css"


### PR DESCRIPTION
…a simple solution) the fetch-to-favorite seems to work even with csrf protection enabled. will have to test further